### PR TITLE
fix: Define next value for Subscribable as generic.

### DIFF
--- a/source/types.ts
+++ b/source/types.ts
@@ -24,7 +24,7 @@ export type PartialObserver<T> = Partial<Observer<T>> &
 export type Subscribable<T> = {
   subscribe(observer?: PartialObserver<T>): Unsubscribable;
   subscribe(
-    next?: ((value: number) => void) | null,
+    next?: ((value: T) => void) | null,
     error?: ((error: any) => void) | null,
     complete?: (() => void) | null
   ): Unsubscribable;


### PR DESCRIPTION
Hi Nicholas, I noticed a little glitch in the `Subscribable` type the definition. The `next()` function was set to accept a number.