### PR TITLE
fix: Export patch function.

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -3,6 +3,7 @@
  * can be found in the LICENSE file at https://github.com/cartant/rxjs-interop
  */
 
+export * from "./patch";
 export * from "./symbols";
 export * from "./to-observer";
 export * from "./types";


### PR DESCRIPTION
This pull request will add the missing export for the `patch()` function.