### PR TITLE
Pass through extended InteropObservables

### DIFF
--- a/source/patch.ts
+++ b/source/patch.ts
@@ -6,7 +6,7 @@
 import { observable } from "./symbols";
 import { InteropObservable } from "./types";
 
-export function patch<T>(instance: InteropObservable<T>): InteropObservable<T>;
+export function patch<T extends InteropObservable<any>>(instance: T): T;
 export function patch<T extends new (...args: any[]) => InteropObservable<any>>(
   constructor: T
 ): T;


### PR DESCRIPTION
This pull request will pass through anything that extends an `InteropObservable`. I made the changes to support the following use case:

```typescript
const interop = {
    [ Symbol.observable ] = () => {
        return {
            subscribe: (...args: any) => {
                return { unsubscribe () { } };
            }
        };
    },
    anotherProp: 123
}

const patched = patch(interop);
```

`patched` will not have `anotherProp` on its type definition anymore whereas the implementation of `patch()` leaves it untouched.